### PR TITLE
feat: faster filtering of previously searched Album IDs using GNU comm (Lidarr Audio script)

### DIFF
--- a/lidarr/Audio.service.bash
+++ b/lidarr/Audio.service.bash
@@ -996,13 +996,16 @@ GetMissingCutOffList () {
 				dlnumber="$lidarrMissingTotalRecords"
 			fi
 			log "$page :: missing :: Downloading page $page... ($offset - $dlnumber of $lidarrMissingTotalRecords Results)"
-			lidarrRecords=$(wget --timeout=0 -q -O - "$arrUrl/api/v1/wanted/missing?page=$page&pagesize=$amountPerPull&sortKey=$searchOrder&sortDirection=$searchDirection&apikey=${arrApiKey}" | jq -r '.records[].id')
+      wget --timeout=0 -q -O - "$arrUrl/api/v1/wanted/missing?page=$page&pagesize=$amountPerPull&sortKey=$searchOrder&sortDirection=$searchDirection&apikey=${arrApiKey}" | jq -r '.records[].id' | sort > /config/extended/cache/tocheck.txt
 			log "$page :: missing :: Filtering Album IDs by removing previously searched Album IDs (/config/extended/logs/notfound/<files>)"
-			for lidarrRecordId in $(echo $lidarrRecords); do
+      ls /config/extended/cache/notfound/ | sed "s/--.*//" > /config/extended/cache/notfound.txt
+
+      for lidarrRecordId in $(comm -13 /config/extended/cache/notfound.txt /config/extended/cache/tocheck.txt); do
 				if [ ! -f /config/extended/logs/notfound/$lidarrRecordId--* ]; then
 					touch "/config/extended/cache/lidarr/list/${lidarrRecordId}-missing"
 				fi
 			done
+      rm /config/extended/cache/notfound.txt /config/extended/cache/tocheck.txt
 			
 			lidarrMissingRecords=$(ls /config/extended/cache/lidarr/list 2>/dev/null | wc -l)
 			log "$page :: missing :: ${lidarrMissingRecords} albums found to process!"
@@ -1034,14 +1037,18 @@ GetMissingCutOffList () {
 			fi
 
 			log "$page :: cutoff :: Downloading page $page... ($offset - $dlnumber of $lidarrCutoffTotalRecords Results)"
-			lidarrRecords=$(wget --timeout=0 -q -O - "$arrUrl/api/v1/wanted/cutoff?page=$page&pagesize=$amountPerPull&sortKey=$searchOrder&sortDirection=$searchDirection&apikey=${arrApiKey}" | jq -r '.records[].id')
+			# lidarrRecords=$(wget --timeout=0 -q -O - "$arrUrl/api/v1/wanted/cutoff?page=$page&pagesize=$amountPerPull&sortKey=$searchOrder&sortDirection=$searchDirection&apikey=${arrApiKey}" | jq -r '.records[].id')
+      wget --timeout=0 -q -O - "$arrUrl/api/v1/wanted/cutoff?page=$page&pagesize=$amountPerPull&sortKey=$searchOrder&sortDirection=$searchDirection&apikey=${arrApiKey}" | jq -r '.records[].id' | sort > /config/extended/cache/tocheck.txt
+
 			log "$page :: cutoff :: Filtering Album IDs by removing previously searched Album IDs (/config/extended/logs/notfound/<files>)"
-			
-			for lidarrRecordId in $(echo $lidarrRecords); do
+			ls /config/extended/cache/notfound/ | sed "s/--.*//" > /config/extended/cache/notfound.txt
+
+      for lidarrRecordId in $(comm -13 /config/extended/cache/notfound.txt /config/extended/cache/tocheck.txt); do
 				if [ ! -f /config/extended/logs/notfound/$lidarrRecordId--* ]; then
 					touch /config/extended/cache/lidarr/list/${lidarrRecordId}-cutoff
 				fi
 			done
+      rm /config/extended/cache/notfound.txt /config/extended/cache/tocheck.txt
 
 			lidarrCutoffRecords=$(ls /config/extended/cache/lidarr/list/*-cutoff 2>/dev/null | wc -l)
 			log "$page :: cutoff :: ${lidarrCutoffRecords} ablums found to process!"

--- a/lidarr/Audio.service.bash
+++ b/lidarr/Audio.service.bash
@@ -998,7 +998,7 @@ GetMissingCutOffList () {
 			log "$page :: missing :: Downloading page $page... ($offset - $dlnumber of $lidarrMissingTotalRecords Results)"
       wget --timeout=0 -q -O - "$arrUrl/api/v1/wanted/missing?page=$page&pagesize=$amountPerPull&sortKey=$searchOrder&sortDirection=$searchDirection&apikey=${arrApiKey}" | jq -r '.records[].id' | sort > /config/extended/cache/tocheck.txt
 			log "$page :: missing :: Filtering Album IDs by removing previously searched Album IDs (/config/extended/logs/notfound/<files>)"
-      ls /config/extended/cache/notfound/ | sed "s/--.*//" > /config/extended/cache/notfound.txt
+      ls /config/extended/logs/notfound/ | sed "s/--.*//" > /config/extended/cache/notfound.txt
 
       for lidarrRecordId in $(comm -13 /config/extended/cache/notfound.txt /config/extended/cache/tocheck.txt); do
 				if [ ! -f /config/extended/logs/notfound/$lidarrRecordId--* ]; then
@@ -1041,7 +1041,7 @@ GetMissingCutOffList () {
       wget --timeout=0 -q -O - "$arrUrl/api/v1/wanted/cutoff?page=$page&pagesize=$amountPerPull&sortKey=$searchOrder&sortDirection=$searchDirection&apikey=${arrApiKey}" | jq -r '.records[].id' | sort > /config/extended/cache/tocheck.txt
 
 			log "$page :: cutoff :: Filtering Album IDs by removing previously searched Album IDs (/config/extended/logs/notfound/<files>)"
-			ls /config/extended/cache/notfound/ | sed "s/--.*//" > /config/extended/cache/notfound.txt
+			ls /config/extended/logs/notfound/ | sed "s/--.*//" > /config/extended/cache/notfound.txt
 
       for lidarrRecordId in $(comm -13 /config/extended/cache/notfound.txt /config/extended/cache/tocheck.txt); do
 				if [ ! -f /config/extended/logs/notfound/$lidarrRecordId--* ]; then


### PR DESCRIPTION
Thought you might be interested in this. While the former Audio.sh re-runs over my (rather large) Lidarr library, a significant amount of 100% CPU time is spent in the "Filtering Album IDs by removing previously searched Album IDs" step. 

Rather than do a lot of looped filesystem access in bash, it turns out to be much faster to compare sorted lists of the Album IDs using the GNU comm program (which is pretty standard, in coreutils). So I dump the two lists being compared into /config/extended/cache. 

`comm -13` directs comm to only output "column 2", which are the lines unique to the second file argument, i.e. the wanted files.

Feel free to refactor to match your style.