### PR TITLE
Modify sed to only remove first `/`

### DIFF
--- a/universal/functions.bash
+++ b/universal/functions.bash
@@ -22,7 +22,7 @@ getArrAppInfo () {
     if [ "$arrUrlBase" == "null" ]; then
       arrUrlBase=""
     else
-      arrUrlBase="/$(echo "$arrUrlBase" | sed "s/\///g")"
+      arrUrlBase="/$(echo "$arrUrlBase" | sed "s/\///")"
     fi
     arrName="$(cat /config/config.xml | xq | jq -r .Config.InstanceName)"
     arrApiKey="$(cat /config/config.xml | xq | jq -r .Config.ApiKey)"


### PR DESCRIPTION
Removes global sed flag so that only the first `/` is removed from the arrUrlBase config parameter.

Fixes https://github.com/RandomNinjaAtk/arr-scripts/issues/165