### PR TITLE
Always use most accurate way of fuzzy matching, greatly improve performance of fuzzy matching

### DIFF
--- a/lidarr/setup.bash
+++ b/lidarr/setup.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/with-contenv bash
 SMA_PATH="/usr/local/sma"
-version="1.0"
+version="1.1"
 
 echo "*** install packages ***" && \
 apk add -U --upgrade --no-cache \
@@ -27,6 +27,7 @@ echo "*** install python packages ***" && \
 pip install --upgrade --no-cache-dir \
   beets \
   yq \
+  pyxDamerauLevenshtein \
   pyacoustid \
   requests \
   pylast \
@@ -46,7 +47,7 @@ touch ${SMA_PATH}/config/sma.log && \
 chgrp users ${SMA_PATH}/config/sma.log && \
 chmod g+w ${SMA_PATH}/config/sma.log && \
 echo "************ install pip dependencies ************" && \
-python3 -m pip install --upgrade pip && \	
+python3 -m pip install --upgrade pip && \
 pip3 install -r ${SMA_PATH}/setup/requirements.txt
 
 mkdir -p /custom-services.d


### PR DESCRIPTION
I found the Bash implementation of calculating the Levenshtein distance to take between ~2-5 seconds depending on the input, using the Python module (important to note that it uses Cython) is MUCH faster:
```
time python -c 'from pyxdameraulevenshtein import damerau_levenshtein_distance; print(damerau_levenshtein_distance("Very Long Album Title: The Hits Part 2 Vol. 2", "Some Other Album Part One: Vol 1."))'
32

real    0m0.009s
user    0m0.009s
sys     0m0.000s
```
```
time python -c 'from pyxdameraulevenshtein import damerau_levenshtein_distance; print(damerau_levenshtein_distance("Similar Album Title: Part One Vol 1.", "Similar Album Title: Part Two Vol 2."))'
4

real    0m0.015s
user    0m0.012s
sys     0m0.004s
```

Because of this I felt we could remove the rough-but-fast-and-early way of detecting if there's a match.