### PR TITLE
Fix Issue #189

### DIFF
--- a/lidarr/ARLChecker
+++ b/lidarr/ARLChecker
@@ -1,11 +1,22 @@
 #!/usr/bin/with-contenv bash
-scriptVersion="0.1"
+### Default values
+scriptVersion="1.1"
 scriptName="ARLChecker"
-
+sleepInterval='24h'
 ### Import Settings
 source /config/extended.conf
 
 echo Starting ARL Token Check...
-python /custom-services.d/python/ARLChecker.py -c
-echo ARL Token Check Complete. Sleeping for 24hrs...
-sleep "$arlUpdateInterval"
+python /custom-services.d/python/ARLChecker.py -c # run py script
+
+# If variable doesn't exist, or not set by user in extended.conf, fallback to 24h
+# See issue #189
+if [[ -v arlUpdateInterval ]] && [ "$arlUpdateInterval" != "" ];then
+	echo 'conf'
+	sleepInterval="$arlUpdateInterval"
+else
+	echo 'default'
+fi
+
+echo ARL Token Check Complete. Sleeping for ${sleepInterval}.
+sleep ${sleepInterval}

--- a/lidarr/ARLChecker
+++ b/lidarr/ARLChecker
@@ -2,7 +2,7 @@
 ### Default values
 scriptVersion="1.1"
 scriptName="ARLChecker"
-sleepInterval='10s'
+sleepInterval='24h'
 ### Import Settings
 source /config/extended.conf
 

--- a/lidarr/ARLChecker
+++ b/lidarr/ARLChecker
@@ -2,20 +2,22 @@
 ### Default values
 scriptVersion="1.1"
 scriptName="ARLChecker"
-sleepInterval='24h'
+sleepInterval='10s'
 ### Import Settings
 source /config/extended.conf
 
 echo Starting ARL Token Check...
-python /custom-services.d/python/ARLChecker.py -c # run py script
+# run py script
+python /custom-services.d/python/ARLChecker.py -c
 
 # If variable doesn't exist, or not set by user in extended.conf, fallback to 24h
 # See issue #189
-if [[ -v arlUpdateInterval ]] && [ "$arlUpdateInterval" != "" ];then
-	echo 'conf'
+if [[ -v arlUpdateInterval ]] && [ "$arlUpdateInterval" != "" ]
+then
+	echo 'Found Interval in extended.conf'
 	sleepInterval="$arlUpdateInterval"
 else
-	echo 'default'
+	echo 'Interval Fallback'
 fi
 
 echo ARL Token Check Complete. Sleeping for ${sleepInterval}.


### PR DESCRIPTION
As referenced in #189, If arlUpdateInterval is not set, ARLChecker will run constantly. Set a default value of 12h in the bash file, and it's overwritten if arlUpdateInterval exists in extended.conf, and does not equal "".