### PR TITLE
Fix video script not starting

### DIFF
--- a/lidarr/Video.service.bash
+++ b/lidarr/Video.service.bash
@@ -22,7 +22,7 @@ verifyConfig () {
 		sleep infinity
 	fi
 
-        if [ "$disableImvd" != "true" ]; then
+        if [ "$disableImvd" != "false" ]; then
 		log "Script is not enabled, enable by setting disableImvd to \"false\" by modifying the \"/config/extended.conf\" config file..."
 		log "Sleeping (infinity)"
 		sleep infinity


### PR DESCRIPTION
If I understood the intention here correctly this should be inverted. Otherwise the video script never starts, even when `enableVideo` is `true`.