### PR TITLE
2.43 - Add interval sleep before exit

### DIFF
--- a/lidarr/Audio.service.bash
+++ b/lidarr/Audio.service.bash
@@ -1,5 +1,5 @@
 #!/usr/bin/with-contenv bash
-scriptVersion="2.42"
+scriptVersion="2.43"
 scriptName="Audio"
 
 ### Import Settings
@@ -206,6 +206,8 @@ DownloadFormat () {
 			log "ERROR :: Change audioBitrate to a low, high, or lossless..."
 			log "ERROR :: Exiting..."
 			NotifyWebhook "FatalError" "Invalid audioFormat and audioBitrate options set"
+			log "Script sleeping for $audioScriptInterval..."
+			sleep $audioScriptInterval
 			exit
 		fi
 	else
@@ -228,6 +230,8 @@ DownloadFormat () {
 			log "ERROR :: Change audioBitrate to a desired bitrate number, example: 192..."
 			log "ERROR :: Exiting..."
 			NotifyWebhook "FatalError" "audioBitrate options set"
+   			log "Script sleeping for $audioScriptInterval..."
+			sleep $audioScriptInterval
 			exit
 		fi
 
@@ -244,6 +248,8 @@ DownloadFormat () {
 			log "ERROR :: Invalid audioFormat options set..."
 			log "ERROR :: Change audioFormat to a desired format (opus or mp3 or aac or alac)"
 			NotifyWebhook "FatalError" "audioFormat options set"
+   			log "Script sleeping for $audioScriptInterval..."
+			sleep $audioScriptInterval
 			exit
 		fi
 
@@ -369,6 +375,8 @@ TidalClientTest () {
 		rm -rf "$audioPath"/incomplete/*
 		NotifyWebhook "Error" "TIDAL not authenticated but configured"
   		tidalClientTest="failed"
+    		log "Script sleeping for $audioScriptInterval..."
+		sleep $audioScriptInterval
 		exit
 	else
 		rm -rf "$audioPath"/incomplete/*
@@ -972,6 +980,8 @@ DeezerClientTest () {
 		rm -rf $audioPath/incomplete/*
 		NotifyWebhook "Error" "DEEZER not authenticated but configured"
   		deezerClientTest="fail"
+    		log "Script sleeping for $audioScriptInterval..."
+		sleep $audioScriptInterval
 		exit
 	else
 		rm -rf $audioPath/incomplete/*
@@ -987,6 +997,8 @@ LidarrRootFolderCheck () {
 		log "ERROR :: Configure root folder in Lidarr to continue..."
 		log "ERROR :: Exiting..."
 		NotifyWebhook "FatalError" "No root folder found"
+  		log "Script sleeping for $audioScriptInterval..."
+		sleep $audioScriptInterval
 		exit
 	fi
 }


### PR DESCRIPTION
While developing on a default Lidarr container, I noticed there would be Audio script looping due to exits without sleep intervals. Example below. Added those sleep intervals. 

# v2.42
![image](https://github.com/RandomNinjaAtk/arr-scripts/assets/7758029/573a4ec0-a5ca-46bb-b343-621023ffb0be)

# v2.43
![image](https://github.com/RandomNinjaAtk/arr-scripts/assets/7758029/5840b1cd-4d9b-4422-8e7c-97c5f0be76a3)
