### PR TITLE
Embed Synced Lyrics with Beets 2.0 + Unpeg Jellyfish Version 

### DIFF
--- a/lidarr/beets-config-lidarr.yaml
+++ b/lidarr/beets-config-lidarr.yaml
@@ -1,9 +1,14 @@
-plugins: chroma embedart lastgenre importadded
+plugins: chroma embedart lastgenre importadded lyrics
 art_filename: folder
 threaded: yes
 per_disc_numbering: yes
 id3v23: no
 asciify_paths: true
+
+lyrics:
+    auto: yes
+    sources: lrclib genius tekstowo
+    synced: yes
 
 match:
     strong_rec_thresh: 0.10 # 0.04

--- a/lidarr/beets-config.yaml
+++ b/lidarr/beets-config.yaml
@@ -1,9 +1,14 @@
-plugins: chroma embedart lastgenre
+plugins: chroma embedart lastgenre lyrics
 art_filename: folder
 threaded: yes
 per_disc_numbering: yes
 id3v23: no
 asciify_paths: true
+
+lyrics:
+    auto: yes
+    sources: lrclib genius tekstowo
+    synced: yes
 
 match:
     strong_rec_thresh: 0.10 # 0.04

--- a/lidarr/setup.bash
+++ b/lidarr/setup.bash
@@ -24,7 +24,7 @@ apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing atomicpa
 npm install -g miraclx/freyr-js &&\
 echo "*** install python packages ***" && \
 pip install --upgrade --no-cache-dir --break-system-packages \
-  jellyfish==1.0.4 \
+  jellyfish \
   beautifulsoup4 \
   yt-dlp \
   beets \

--- a/lidarr/setup.bash
+++ b/lidarr/setup.bash
@@ -24,7 +24,8 @@ apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing atomicpa
 npm install -g miraclx/freyr-js &&\
 echo "*** install python packages ***" && \
 pip install --upgrade --no-cache-dir --break-system-packages \
-  jellyfish==0.10 \
+  jellyfish==1.0.4 \
+  beautifulsoup4 \
   yt-dlp \
   beets \
   yq \


### PR DESCRIPTION
### This PR addresses 2 issues:

## #204 [FEATURE] - Updates Beets to 1.6.1 in Lidarr scripts

Beets has a new 2.0 release, and with it comes embedded lyric support. See [here](https://github.com/RandomNinjaAtk/arr-scripts/issues/204#issuecomment-2179737013) for the effects. Implement embedded lyrics, preferring synced lyrics and falling back to static (using Genius and tekstowo as a source). Install BeautifulSoup for static lyrics support per Beets documentation.

## Jellyfish pegged at 0.10
This was first found while implementing Feature #187, and a band aid was applied, PR #217 to fix Issue #216.  Since the LinuxServer.io image runs on Alpine, a binary needs to be built for musl linux. When the Jellyfish team changed their package to be written in rust, they forgot to build the binary. I pegged Jellyfish at 0.10, the last version before moving to rust. I created an issue [here](https://github.com/jamesturk/jellyfish/issues/209), and they added musl linux to their build chain in the latest version, so it shouldn't be an issue going forward.