### PR TITLE
Update setup.bash with dotnet8-runtime (Radarr)

### DIFF
--- a/radarr/setup.bash
+++ b/radarr/setup.bash
@@ -41,7 +41,7 @@ mkdir -p /recyclarr && \
 wget "https://github.com/recyclarr/recyclarr/releases/latest/download/recyclarr-linux-musl-x64.tar.xz" -O "/recyclarr/recyclarr.tar.xz" && \
 tar -xf /recyclarr/recyclarr.tar.xz -C /recyclarr &>/dev/null && \
 chmod 777 /recyclarr/recyclarr
-apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/community dotnet7-runtime
+apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/community dotnet8-runtime
 
 mkdir -p /custom-services.d
 echo "Download QueueCleaner service..."


### PR DESCRIPTION
Recyclarr would not download/run with dotnet7, if you follow the alpine linux url, you will find that dotnet7-runtime does not exist. When I forked this and modified it to dotnet8, it worked on the first try. This needs to be fixed in sonarr and radarr.