### PR TITLE
fix a typo in the update instructions

### DIFF
--- a/lidarr/readme.md
+++ b/lidarr/readme.md
@@ -19,7 +19,7 @@ Container: <https://docs.linuxserver.io/images/docker-lidarr>
   
 ## Updating
 
-Updating is a bit more combersum. To update, do the following:
+Updating is a bit more cumbersome. To update, do the following:
 
 1. Download/update your local `/config/extended.conf` file with the latest options from: [extended.conf](https://github.com/RandomNinjaAtk/arr-scripts/blob/main/lidarr/extended.conf)
 2. Restart the container, wait for it to fully load the application.

--- a/radarr/readme.md
+++ b/radarr/readme.md
@@ -18,7 +18,7 @@ Container: <https://docs.linuxserver.io/images/docker-radarr>
 
 ## Updating
 
-Updating is a bit more combersum. To update, do the following:
+Updating is a bit more cumbersome. To update, do the following:
 
 1. Download/update your local `/config/extended.conf` file with the latest options from: [extended.conf](https://github.com/RandomNinjaAtk/arr-scripts/blob/main/radarr/extended.conf)
 1. Restart the container, wait for it to fully load the application.

--- a/readarr/readme.md
+++ b/readarr/readme.md
@@ -19,7 +19,7 @@ Container: <https://hub.docker.com/r/linuxserver/readarr>
 
 # Updating
 
-Updating is a bit more combersum. To update, do the following:
+Updating is a bit more cumbersome. To update, do the following:
 
 1. Download/update your local `/config/extended.conf` file with the latest options from: [extended.conf](https://github.com/RandomNinjaAtk/arr-scripts/blob/main/readarr/extended.conf)
 1. Restart the container, wait for it to fully load the application.

--- a/sabnzbd/readme.md
+++ b/sabnzbd/readme.md
@@ -18,7 +18,7 @@ Container: [https://docs.linuxserver.io/images/docker-sabnzbd](https://docs.linu
 
 ## Updating
 
-Updating is a bit more combersum. To update, do the following:
+Updating is a bit more cumbersome. To update, do the following:
 
 1. Download/update your local `/config/extended.conf` file with the latest options from: [extended.conf](https://github.com/RandomNinjaAtk/arr-scripts/blob/main/sabnzbd/extended.conf)
 1. Restart the container, wait for it to fully load the application.

--- a/sonarr/readme.md
+++ b/sonarr/readme.md
@@ -19,7 +19,7 @@ Version Tag: develop (v4 is required for some of the features)
 
 ## Updating
 
-Updating is a bit more combersum. To update, do the following:
+Updating is a bit more cumbersome. To update, do the following:
 
 1. Download/update your local `/config/extended.conf` file with the latest options from: [extended.conf](https://github.com/RandomNinjaAtk/arr-scripts/blob/main/sonarr/extended.conf)
 2. Restart the container, wait for it to fully load the application.


### PR DESCRIPTION
Found a small misspelling in the update instructions, fixed it on every readme.