### PR TITLE
Fix rename for TidalVideoDownloader.bash for special characters (analogue audio implementation)

### DIFF
--- a/lidarr/TidalVideoDownloader.bash
+++ b/lidarr/TidalVideoDownloader.bash
@@ -250,7 +250,7 @@ VideoProcess () {
 			videoData=$(echo $tidalVideosData | jq -r "select(.id==$id)")
 			videoTitle=$(echo $videoData | jq -r .title)
 			videoTitleClean="$(echo "$videoTitle" | sed 's%/%-%g')"
-			videoTitleClean="$(echo "$videoTitleClean" | sed -e "s/[:alpha:][:digit:]._' -/ /g" -e "s/  */ /g" | sed 's/^[.]*//' | sed  's/[.]*$//g' | sed  's/^ *//g' | sed 's/ *$//g')"
+			videoTitleClean="$(echo "$videoTitleClean" | sed -e "s/[^[:alpha:][:digit:]$^&_+=()'%;{},.@#]/ /g" -e "s/  */ /g" | sed 's/^[.]*//' | sed  's/[.]*$//g' | sed  's/^ *//g' | sed 's/ *$//g')"
 			videoExplicit=$(echo $videoData | jq -r .explicit)
 			videoUrl="https://tidal.com/browse/video/$id"
 			videoDate="$(echo "$videoData" | jq -r ".releaseDate")"


### PR DESCRIPTION
Fixing issue of special characters in file name corrupting the file