### PR TITLE
fixes #87 [Lidarr] Error: writing output failed: Broken pipe

### DIFF
--- a/lidarr/setup.bash
+++ b/lidarr/setup.bash
@@ -22,6 +22,7 @@ apk add -U --upgrade --no-cache \
   musl-locales-lang \
   flac \
   jq \
+  xq \
   git \
   gcc \
   ffmpeg \

--- a/radarr/setup.bash
+++ b/radarr/setup.bash
@@ -18,6 +18,7 @@ apk add -U --update --no-cache \
   flac \
   opus-tools \
   jq \
+  xq \
   git \
   wget \
   mkvtoolnix \

--- a/readarr/setup.bash
+++ b/readarr/setup.bash
@@ -2,6 +2,7 @@
 echo "************ install and update packages ************"
 apk add -U --update --no-cache \
   jq \
+  xq \
   py3-pip \
   ffmpeg
 echo "************ install python packages ************"

--- a/sonarr/setup.bash
+++ b/sonarr/setup.bash
@@ -18,6 +18,7 @@ apk add -U --update --no-cache \
 	flac \
 	opus-tools \
 	jq \
+	xq \
 	git \
 	wget \
 	mkvtoolnix \


### PR DESCRIPTION
Fixes #87 

`xq` is called by `getArrAppInfo` in `universal/functions.bash`. Installing `xq` in each 'arr `setup.bash` script should fix the pipe errors in this issue. It might also fix the `jq` pipe error in issue 231.