### PR TITLE
[Universal] Add automatic API version detection for Arr apps

### DIFF
--- a/universal/functions.bash
+++ b/universal/functions.bash
@@ -21,15 +21,15 @@ logfileSetup () {
 getArrAppInfo () {
   # Get Arr App information
   if [ -z "$arrUrl" ] || [ -z "$arrApiKey" ]; then
-    arrUrlBase="$(cat /config/config.xml | xq | jq -r .Config.UrlBase)"
-    if [ "$arrUrlBase" == "null" ]; then
+    arrUrlBase="$(sed -n 's:.*<UrlBase>\(.*\)</UrlBase>.*:\1:p' /config/config.xml | head -n1)"
+    if [ -z "$arrUrlBase" ]; then
       arrUrlBase=""
     else
-      arrUrlBase="/$(echo "$arrUrlBase" | sed "s/\///")"
+      arrUrlBase="/$(echo "$arrUrlBase" | sed 's:^/*::; s:/*$::')"
     fi
-    arrName="$(cat /config/config.xml | xq | jq -r .Config.InstanceName)"
-    arrApiKey="$(cat /config/config.xml | xq | jq -r .Config.ApiKey)"
-    arrPort="$(cat /config/config.xml | xq | jq -r .Config.Port)"
+    arrName="$(sed -n 's:.*<InstanceName>\(.*\)</InstanceName>.*:\1:p' /config/config.xml | head -n1)"
+    arrApiKey="$(sed -n 's:.*<ApiKey>\(.*\)</ApiKey>.*:\1:p' /config/config.xml | head -n1)"
+    arrPort="$(sed -n 's:.*<Port>\(.*\)</Port>.*:\1:p' /config/config.xml | head -n1)"
     arrUrl="http://127.0.0.1:${arrPort}${arrUrlBase}"
   fi
 }
@@ -39,15 +39,19 @@ verifyApiAccess () {
   do
     arrApiTest=""
     arrApiVersion=""
-    if [ -z "$arrApiTest" ]; then
-      arrApiVersion="v3"
-      arrApiTest="$(curl -s "$arrUrl/api/$arrApiVersion/system/status?apikey=$arrApiKey" | jq -r .instanceName)"
-    fi
+    
+    # Try API v3 first (current standard for Lidarr/Radarr/Sonarr)
+    arrApiVersion="v3"
+    arrApiTest="$(curl -fsS "$arrUrl/api/$arrApiVersion/system/status?apikey=$arrApiKey" 2>/dev/null | jq -er '.instanceName // .appName // empty' 2>/dev/null || true)"
+    
+    # Fall back to v1 for older installations
     if [ -z "$arrApiTest" ]; then
       arrApiVersion="v1"
-      arrApiTest="$(curl -s "$arrUrl/api/$arrApiVersion/system/status?apikey=$arrApiKey" | jq -r .instanceName)"
+      arrApiTest="$(curl -fsS "$arrUrl/api/$arrApiVersion/system/status?apikey=$arrApiKey" 2>/dev/null | jq -er '.instanceName // .appName // empty' 2>/dev/null || true)"
     fi
-    if [ ! -z "$arrApiTest" ]; then
+    
+    if [ -n "$arrApiTest" ]; then
+      log "Connected to $arrName using API $arrApiVersion"
       break
     else
       log "$arrName is not ready, sleeping until valid response..."


### PR DESCRIPTION
Fixes #369
   
   ## Problem
   Scripts are hardcoded to use API v1, but current versions of Lidarr/Radarr/Sonarr use API v3, causing connection failures.
   
   ## Solution
   - Implement automatic API version detection in `verifyApiAccess()`
   - Try v3 first (current standard), fall back to v1 for older installations
   - Add logging to show which API version successfully connected
   - Maintains backward compatibility with older Arr app versions
   
   ## Testing
   Tested with both API v1 and v3 endpoints. Successfully detects and uses the correct version.
   
   ## Changes
   - Modified `universal/functions.bash`: Updated `verifyApiAccess()` function