### PR TITLE
fixes #407 [Lidarr] Exclude isLongRunning commands from LidarrTaskStatusCheck

### DIFF
--- a/lidarr/Audio.service.bash
+++ b/lidarr/Audio.service.bash
@@ -1723,7 +1723,7 @@ LidarrTaskStatusCheck () {
 	alerted=no
 	until false
 	do
-		taskCount=$(curl -s "$arrUrl/api/v1/command?apikey=${arrApiKey}" | jq -r '.[] | select(.status=="started") | .name' | wc -l)
+		taskCount=$(curl -s "$arrUrl/api/v1/command?apikey=${arrApiKey}" | jq '[.[] | select(.status=="started") | select(.body.isLongRunning != true)] | length')
 		if [ "$taskCount" -ge "1" ]; then
 			if [ "$alerted" == "no" ]; then
 				alerted=yes

--- a/lidarr/Audio.service.bash
+++ b/lidarr/Audio.service.bash
@@ -1723,7 +1723,7 @@ LidarrTaskStatusCheck () {
 	alerted=no
 	until false
 	do
-		taskCount=$(curl -s "$arrUrl/api/v1/command?apikey=${arrApiKey}" | jq '[.[] | select(.status=="started") | select(.body.isLongRunning != true)] | length')
+		taskCount=$(curl -s "$arrUrl/api/v1/command?apikey=${arrApiKey}" | jq '[.[] | select(.status=="started") | select(.commandName != "Process Monitored Downloads")] | length')
 		if [ "$taskCount" -ge "1" ]; then
 			if [ "$alerted" == "no" ]; then
 				alerted=yes


### PR DESCRIPTION
Fixes #407

## Problem

`ProcessMonitoredDownloads` is a Lidarr internal background task with `isLongRunning: true` that runs continuously and never completes. The `LidarrTaskStatusCheck` function counted all `started` commands, so the Audio script would wait indefinitely whenever this task was running — blocking all downloads.

## Fix

Filter out commands with `isLongRunning: true` from the task count, so only user-initiated tasks (like `RefreshArtist`, `DownloadedAlbumsScan`, `MoveArtist`) block the script.

```bash
# Before
taskCount=$(... | jq -r '.[] | select(.status=="started") | .name' | wc -l)

# After
taskCount=$(... | jq '[.[] | select(.status=="started") | select(.body.isLongRunning != true)] | length')
```