### PR TITLE
fixes #411 [Lidarr] Fix BeetsTagger broken pipe: find | read → find | grep -q .

### DIFF
--- a/lidarr/BeetsTagger.bash
+++ b/lidarr/BeetsTagger.bash
@@ -46,7 +46,7 @@ else
 fi
 ProcessWithBeets () {
 	log "$1 :: Start Processing..."
-	if find "$1" -type f -iname "*.flac"  | read; then
+	if find "$1" -type f -iname "*.flac" | grep -q .; then
  		sleep 0.01
    	else
     	log "$1 :: ERROR :: Only supports flac files, exiting..." 


### PR DESCRIPTION
## Summary

- Fixes `find "$1" -type f -iname "*.flac" | read` in `BeetsTagger.bash` line 49
- `read` closes the pipe after the first line, sending SIGPIPE to `find` and producing log errors on every BeetsTagger run
- Replaced with `grep -q .` which exits 0 if any output exists without closing the pipe early

## Test plan

- [ ] BeetsTagger runs without `find: 'standard output': Broken pipe` / `find: write error` log errors
- [ ] Albums with FLAC files are still processed normally
- [ ] Albums without FLAC files still log the "Only supports flac files" error and return

🤖 Generated with [Claude Code](https://claude.com/claude-code)